### PR TITLE
manual converting hash to keyword argument (**) for ruby >= 3.0

### DIFF
--- a/lib/pltt/actions/base.rb
+++ b/lib/pltt/actions/base.rb
@@ -4,8 +4,8 @@ require_relative '../entry'
 require_relative '../colorize'
 
 class Pltt::Actions::Base
-  def self.run(*args)
-    new.run(*args)
+  def self.run(**args)
+    new.run(**args)
   end
 
   def config

--- a/lib/pltt/runner.rb
+++ b/lib/pltt/runner.rb
@@ -14,9 +14,9 @@ class Pltt::Runner < Thor
   end
 
   desc "start [ID]", "start tracking for issue #ID"
-  def start(id = nil)
+  def start(iid: nil)
     require_relative './actions/start'
-    Pltt::Actions::Start.run(id)
+    Pltt::Actions::Start.run(iid: nil)
   end
 
   desc "stop", "Stop"
@@ -40,9 +40,9 @@ class Pltt::Runner < Thor
   end
 
   desc "edit [ID = CURRENT]", "start tracking for issue #ID"
-  def edit(id = nil)
+  def edit(id: nil)
     require_relative './actions/edit'
-    Pltt::Actions::Edit.run(id)
+    Pltt::Actions::Edit.run(id: nil)
   end
 
   desc "cancel", "cancel current entry"


### PR DESCRIPTION
Damit läuft dann wieder pltt list ohne `wrong number of arguments (given 1, expected 0) (ArgumentError)`.